### PR TITLE
Improve the description of the phpPath setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       "title": "PHP Path",
       "type": "string",
       "default": "",
-      "description": "Absolute path to PHP 7 folder used to launch the PHP language server."
+      "description": "Absolute path to the folder containing your PHP 7 binary (e.g., /usr/local/bin if your php is at /usr/local/bin/php). This is used to launch the PHP language server."
     },
     "memoryLimit": {
       "title": "Memory Limit",


### PR DESCRIPTION
Issue #37 implies that some people are entering the full path to their php binary in the phpPath setting (e.g., /usr/local/bin/php) which leads to a silent failure and then Uncaught Error: spawn ENOTDIR in the console log.

Using the path to the folder containing the php binary (e.g., /usr/local/bin) seems to work. On the assumption that the setting is correct, and it is us users that are wrong, I've added a few more words to the description of the setting.