### PR TITLE
use busy-signal instead of status bar

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -17,8 +17,7 @@ class PHPLanguageClient extends AutoLanguageClient {
 
   constructor () {
     super()
-    this.statusElement = document.createElement('span')
-    this.statusElement.className = 'inline-block'
+    this.busySignalElement = null
   }
 
   startServerProcess () {
@@ -113,10 +112,7 @@ class PHPLanguageClient extends AutoLanguageClient {
       const childProcess = cp.spawn(command, args, { cwd: serverHome })
       this.captureServerErrors(childProcess)
       childProcess.on('exit', exitCode => {
-        if (exitCode == 0 || exitCode == null) {
-          this.updateStatusBar()
-        } else {
-          this.updateStatusBar('stopped')
+        if (exitCode != 0 && exitCode != null) {
           atom.notifications.addError('IDE-PHP language server stopped unexpectedly.', {
             dismissable: true,
             description: this.processStdErr != null ? `<code>${this.processStdErr}</code>` : `Exit code ${exitCode}`
@@ -142,31 +138,42 @@ class PHPLanguageClient extends AutoLanguageClient {
     this.logger.log(`Downloading ${serverDownloadUrl} to ${localFileName}`);
     return this.fileExists(serverHome)
       .then(doesExist => { if (!doesExist) fs.mkdirSync(serverHome) })
-      .then(() => DownloadFile(serverDownloadUrl, localFileName, (bytesDone, percent) => this.updateStatusBar(`downloading ${percent}%`), serverDownloadSize))
-      .then(() => this.updateStatusBar('unpacking'))
+      .then(() => DownloadFile(serverDownloadUrl, localFileName, (bytesDone, percent) => this.updateBusySignal(`downloading ${percent}%`), serverDownloadSize))
+      .then(() => this.updateBusySignal('unpacking'))
       .then(() => decompress(localFileName, serverHome))
+      .then(() => this.updateBusySignal())
       .then(() => this.fileExists(path.join(serverHome, serverLauncher)))
       .then(doesExist => { if (!doesExist) throw Error(`Failed to install the ${this.getServerName()} language server`) })
-      .then(() => this.updateStatusBar('installed'))
       .then(() => fs.unlinkSync(localFileName))
   }
 
   preInitialization(connection) {
-    this.updateStatusBar('started')
+    this.updateBusySignal()
   }
 
-  updateStatusBar (text) {
+  updateBusySignal (text) {
+    if (!this.busySignal) {
+      // busy signal not available
+      return;
+    }
+
     if (text == null || text === '') {
-      this.statusElement.hidden = true
-      this.statusElement.textContent = ''
+      if (this.busySignalElement != null) {
+        this.busySignalElement.dispose()
+        this.busySignalElement = null
+      }
+    } else if (this.busySignalElement == null) {
+      this.busySignalElement = this.busySignal.reportBusy(`${this.name} ${text}`, {
+        waitingFor: 'computer',
+        revealTooltip: true
+      })
     } else {
-      this.statusElement.hidden = false
-      this.statusElement.textContent = `${this.name} ${text}`
+      this.busySignalElement.setTitle(`${this.name} ${text}`)
     }
   }
 
-  consumeStatusBar (statusBar) {
-    this.statusTile = statusBar.addRightTile({ item: this.statusElement, priority: 1000 })
+  consumeBusySignal (busySignal) {
+    this.busySignal = busySignal
   }
 
   getPHPCommand () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -163,10 +163,7 @@ class PHPLanguageClient extends AutoLanguageClient {
         this.busySignalElement = null
       }
     } else if (this.busySignalElement == null) {
-      this.busySignalElement = this.busySignal.reportBusy(`${this.name} ${text}`, {
-        waitingFor: 'computer',
-        revealTooltip: true
-      })
+      this.busySignalElement = this.busySignal.reportBusy(`${this.name} ${text}`, { revealTooltip: true })
     } else {
       this.busySignalElement.setTitle(`${this.name} ${text}`)
     }

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
         "2.0.0": "consumeLinterV2"
       }
     },
-    "status-bar": {
+    "atom-ide-busy-signal": {
       "versions": {
-        "^1.0.0": "consumeStatusBar"
+        "0.1.0": "consumeBusySignal"
       }
     },
     "datatip": {


### PR DESCRIPTION
Use [busy-signal](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/busy-signal.md) instead of status-bar to display the downloading notification.

The [revealTooltip](https://github.com/facebook-atom/atom-ide-ui/blob/master/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/types.js#L27) option is set to true so the tooltip is visible immediately without the user needing to hover over busy-signal

fixes #29