### PR TITLE
Exclude non-essential files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,4 @@
 {
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "felixfbecker/language-server": "^4.6.1"
     },
@@ -8,5 +6,10 @@
         "parse-stubs": "LanguageServer\\ComposerScripts::parseStubs",
         "post-update-cmd": "@parse-stubs",
         "post-install-cmd": "@parse-stubs"
-    }
+    },
+    "config": {
+        "preferred-install": "dist"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -383,12 +383,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "ae6536aa2165808d963915d38ec624a23e9747ca"
+                "reference": "577ae4e14e3c18acc50a422b39187364003f9073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/ae6536aa2165808d963915d38ec624a23e9747ca",
-                "reference": "ae6536aa2165808d963915d38ec624a23e9747ca",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/577ae4e14e3c18acc50a422b39187364003f9073",
+                "reference": "577ae4e14e3c18acc50a422b39187364003f9073",
                 "shasum": ""
             },
             "type": "library",
@@ -408,7 +408,7 @@
                 "stubs",
                 "type"
             ],
-            "time": "2017-09-11T17:10:04+00:00"
+            "time": "2017-09-20T17:50:10+00:00"
         },
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
[Exclude non-essential files in .gitattributes](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/). This way the users of this package doesn't have to download non-essential files of `felixfbecker/php-language-server` package such as the `tests` directory or the `.travis.yml` file.

https://github.com/felixfbecker/php-language-server/pull/486