### PR TITLE
fix typo in main file

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -184,7 +184,7 @@ class PHPLanguageClient extends AutoLanguageClient {
         atom.notifications.addWarning('Invalid connection type setting', {
           dismissable: true,
           buttons: [ { text: 'Set Connection Type', onDidClick: () => this.openPackageSettings() } ],
-          description: 'The connection type setting should be set to "auto", "socket" or "stdio". "auto" is "socket" on Window and "stdio" on other platforms.'
+          description: 'The connection type setting should be set to "auto", "socket" or "stdio". "auto" is "socket" on Windows and "stdio" on other platforms.'
         })
     }
   }


### PR DESCRIPTION
I'm not using the package at all, but I just saw that typo as I read the code.