### PR TITLE
Replace line-breaks in HTML description

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,6 +22,12 @@ class PHPLanguageClient extends AutoLanguageClient {
     provide.suggestionPriority = atom.config.get('ide-php.autocompletePriority') === 'lower' ? 1 : 2
     return provide
   }
+  
+  onDidConvertAutocomplete(completionItem, suggestion, request) {
+    if (/<[a-z][\s\S]*>/i.test(suggestion.description)) {
+      suggestion.descriptionMarkdown = suggestion.description.replace(/\n/g, '');
+    }
+  }
 
   startServerProcess () {
     const serverHome = path.join(__dirname, '..', 'vendor')


### PR DESCRIPTION
This pull request remove line-breaks from `description` containing HTML. It will clean up the description and make them easier to read:
<img width="555" src="https://user-images.githubusercontent.com/499192/48513981-95f0f800-e85d-11e8-9e1c-eaf00ccf152c.png">

This pull request is **blocked** by: https://github.com/atom/autocomplete-plus/pull/1003
