### PR TITLE
Set lower-than-default priority for language-server

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,7 @@
 const cp = require('child_process')
 const fs = require('fs')
 const net = require('net')
+const os = require('os');
 const path = require('path')
 const {shell} = require('electron')
 const {AutoLanguageClient, DownloadFile} = require('atom-languageclient')
@@ -22,7 +23,7 @@ class PHPLanguageClient extends AutoLanguageClient {
     provide.suggestionPriority = atom.config.get('ide-php.autocompletePriority') === 'lower' ? 1 : 2
     return provide
   }
-  
+
   onDidConvertAutocomplete(completionItem, suggestion, request) {
     if (/<[a-z][\s\S]*>/i.test(suggestion.description)) {
       suggestion.descriptionMarkdown = suggestion.description.replace(/\n/g, '');
@@ -139,6 +140,7 @@ class PHPLanguageClient extends AutoLanguageClient {
 
       this.logger.debug(`starting "${command} ${args.join(' ')}"`)
       const childProcess = cp.spawn(command, args, { cwd: serverHome })
+      os.setPriority(childProcess.pid, os.constants.priority.PRIORITY_BELOW_NORMAL);
       this.captureServerErrors(childProcess)
       childProcess.on('exit', exitCode => {
         if (exitCode != 0 && exitCode != null) {


### PR DESCRIPTION
### Description of the Change
Use [Node's `os` module to set the priority of the external process](https://nodejs.org/api/os.html#os_os_setpriority_pid_priority) spawned by this extension to be below normal. This means that Atom and other processes that the user is actively interacting with will not be adversely affected by the background process that this extension needs. This will in some cases mean that the features provided by this extension may not be available as quickly initially, as the language server reads files and generates an index. It's up to the operating system to determine which processes are allowed CPU time; setting the priority of this background process helps it decide which processes are important to the user and which can be delayed when resources are scarce.

### Quantitative Performance Benefits
When the language server starts, it consumes 100% of one CPU core on my computers. When the change here is applied, the same occurs, however the process is running with a lower priority (higher 'nice' number), so the operating system is able to suitably prioritise other processes instead of this. In my test cases, adjacent long-running processes (eg, encoding a video with `ffmpeg`, compiling programs with `gcc` and `clang`) completed sooner. The differences are more noticeable with larger projects and when the system is otherwise very busy / low on resources.

### Possible Drawbacks
The features provided by this extension may not be available to users as quickly as without this change. This will only be a problem for users whose system is already under stress / low on available resources. Normal operation of this extension after the language server has finished its initial processing and generated its internal index will not be adversely affected by this change.

### Verification Process
I tested the following features within a known-working project with this change applied (when using `atom --dev --foreground /path/to/big-project`)
- Auto completion (`SomeClass::CONSTANT_NAME`, `$object->method()`)
- Hover (tool-tip shows up as normal for PHP built-in functions and indexed methods)
- Signature help (I'll often refer to these as PHP is inconsistent with its parameter ordering)

Given the changes involved in this pull request, only minimal testing was carried out.

### Applicable Issues
- https://github.com/atom/ide-php/issues/108
- https://github.com/atom/ide-php/issues/143

### Release Notes
Set background process at lower priority to improve CPU availability